### PR TITLE
Update FillDocx.node.ts

### DIFF
--- a/nodes/FillDocx/FillDocx.node.ts
+++ b/nodes/FillDocx/FillDocx.node.ts
@@ -108,15 +108,7 @@ export class FillDocx implements INodeType {
 
 			const binaryDataBuffer = await this.helpers.getBinaryDataBuffer(itemIndex, sourceKey);
 
-			const handler = new TemplateHandler({
-				delimiters: {
-					tagStart: '{{',
-					tagEnd: '}}',
-					containerTagOpen: '#',
-					containerTagClose: '/',
-				},
-				maxXmlDepth: 100,
-			});
+			const handler = new TemplateHandler();
 
 			try {
 				const doc = await handler.process(binaryDataBuffer, templateData);


### PR DESCRIPTION
Make it compatible with the default values instead of using {{ }} , now loops are working too without extra added things